### PR TITLE
feat: use wasm piece hasher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "ansi-escapes": "^6.2.0",
         "chalk": "^5.3.0",
         "files-from-path": "^1.0.4",
+        "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.3.0",
         "open": "^9.1.0",
         "ora": "^7.0.1",
         "pretty-tree": "^1.0.0",
@@ -3795,8 +3796,7 @@
     "node_modules/fr32-sha2-256-trunc254-padded-binary-tree-multihash": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/fr32-sha2-256-trunc254-padded-binary-tree-multihash/-/fr32-sha2-256-trunc254-padded-binary-tree-multihash-3.3.0.tgz",
-      "integrity": "sha512-O11VDxPmPvbQj5eac2BJXyieNacyd+RCMhwOzXQQM/NCI25x3c32YWB4/JwgOWPCpKnNXF6lpK/j0lj7GWOnYQ==",
-      "dev": true
+      "integrity": "sha512-O11VDxPmPvbQj5eac2BJXyieNacyd+RCMhwOzXQQM/NCI25x3c32YWB4/JwgOWPCpKnNXF6lpK/j0lj7GWOnYQ=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ansi-escapes": "^6.2.0",
     "chalk": "^5.3.0",
     "files-from-path": "^1.0.4",
+    "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.3.0",
     "open": "^9.1.0",
     "ora": "^7.0.1",
     "pretty-tree": "^1.0.0",


### PR DESCRIPTION
We removed this from the client library (and use the JS native version) since there's a miriad of environments that JS runs in that have differing ways to load WASM. However in Node.js it's a captive environment so should load fine and give us a little speedup.